### PR TITLE
Add lecturer management

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { AuthService } from './services/auth/auth.service';
 import { UserService } from './services/user/user.service';
 import { StudentService } from './services/student/student.service';
+import { LecturerService } from './services/lecturer/lecturer.service';
 
 // Pipes
 import { FilterPipe } from './pipes/filter.pipe';
@@ -23,6 +24,9 @@ import { AppComponent } from './components/index/app.component';
 import { StudentListComponent } from './components/student/list/student-list.component';
 import { StudentDetailsComponent } from './components/student/details/student-details.component';
 import { StudentAddComponent } from './components/student/add/student-add.component';
+import { LecturerListComponent } from './components/lecturer/list/lecturer-list.component';
+import { LecturerDetailsComponent } from './components/lecturer/details/lecturer-details.component';
+import { LecturerAddComponent } from './components/lecturer/add/lecturer-add.component';
 import { LoginComponent } from './components/login/login.component';
 import { HomeComponent, homeChildRoutes } from './components/home/home.component';
 import { HighlightStudentDirective } from './directives/highlight-student.directive';
@@ -48,13 +52,16 @@ const routes: Routes = [
 ];
 
 @NgModule({
-	declarations: [
-		AppComponent,
-		StudentListComponent,
-		StudentDetailsComponent,
-		StudentAddComponent,
-		LoginComponent,
-		HomeComponent,
+        declarations: [
+                AppComponent,
+                StudentListComponent,
+                StudentDetailsComponent,
+                StudentAddComponent,
+                LecturerListComponent,
+                LecturerDetailsComponent,
+                LecturerAddComponent,
+                LoginComponent,
+                HomeComponent,
 		FilterPipe,
 		PhonePipe,
 		HighlightStudentDirective
@@ -72,7 +79,7 @@ const routes: Routes = [
 			preventDuplicates: true,
 		}),
 	],
-	providers: [AuthService, UserService, StudentService],
+        providers: [AuthService, UserService, StudentService, LecturerService],
 	bootstrap: [AppComponent]
 })
 

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -5,8 +5,10 @@
 	<!-- Logo -->
 	<a href="https://sangw.in" target="_blank"><img src="assets/sangwin-logo.png" class="logo"></a>
 	<!-- Sidebar Links -->
-	<a class="w3-bar-item w3-button" [ngClass]="{'w3-teal': (active == '/')}" routerLink="/"> <i class="w3-medium fa fa-user"></i>  User List</a>
-	<a class="w3-bar-item w3-button" routerLink="/add"  [ngClass]="{'w3-teal': (active == '/add')}"> <i class="w3-medium fa fa-plus"></i>  Add new user</a>
+        <a class="w3-bar-item w3-button" [ngClass]="{'w3-teal': (active == '/') }" routerLink="/"> <i class="w3-medium fa fa-user"></i>  Student List</a>
+        <a class="w3-bar-item w3-button" routerLink="/add"  [ngClass]="{'w3-teal': (active == '/add')}"> <i class="w3-medium fa fa-plus"></i>  Add new student</a>
+        <a class="w3-bar-item w3-button" [ngClass]="{'w3-teal': (active == '/lecturers') }" routerLink="/lecturers"> <i class="w3-medium fa fa-users"></i>  Lecturer List</a>
+        <a class="w3-bar-item w3-button" routerLink="/lecturers/add"  [ngClass]="{'w3-teal': (active == '/lecturers/add')}"> <i class="w3-medium fa fa-plus"></i>  Add new lecturer</a>
 	<a class="w3-bar-item w3-button" (click)="logOut()"><i class="w3-medium fa fa-sign-out"></i>  Logout</a>
 </nav>
 

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -10,6 +10,9 @@ import { ToastrService } from 'ngx-toastr';
 import { StudentListComponent } from '../student/list/student-list.component';
 import { StudentDetailsComponent } from '../student/details/student-details.component';
 import { StudentAddComponent } from '../student/add/student-add.component';
+import { LecturerListComponent } from '../lecturer/list/lecturer-list.component';
+import { LecturerDetailsComponent } from '../lecturer/details/lecturer-details.component';
+import { LecturerAddComponent } from '../lecturer/add/lecturer-add.component';
 
 // Services
 import { routerTransition } from '../../services/config/config.service';
@@ -52,10 +55,10 @@ export class HomeComponent implements OnInit {
 
 // Define and export child routes of HomeComponent
 export const homeChildRoutes: Routes = [
-	{
-		path: '',
-		component: StudentListComponent
-	},
+        {
+                path: '',
+                component: StudentListComponent
+        },
 	{
 		path: 'add',
 		component: StudentAddComponent
@@ -64,10 +67,26 @@ export const homeChildRoutes: Routes = [
 		path: 'update/:id',
 		component: StudentAddComponent
 	},
-	{
-		path: 'detail/:id',
-		component: StudentDetailsComponent
-	}
+        {
+                path: 'detail/:id',
+                component: StudentDetailsComponent
+        },
+        {
+                path: 'lecturers',
+                component: LecturerListComponent
+        },
+        {
+                path: 'lecturers/add',
+                component: LecturerAddComponent
+        },
+        {
+                path: 'lecturers/update/:id',
+                component: LecturerAddComponent
+        },
+        {
+                path: 'lecturers/detail/:id',
+                component: LecturerDetailsComponent
+        }
 ];
 
 /**

--- a/src/app/components/index/app.component.ts
+++ b/src/app/components/index/app.component.ts
@@ -14,8 +14,8 @@ import { Component } from '@angular/core';
 export class AppComponent {
 	title = 'Student Management By Sangwin Gawande';
 
-	// Add few students for initial listing
-	studentsList = [
+        // Add few students for initial listing
+        studentsList = [
 	{	
 		id : 1,
 		first_name : "Sangwin",
@@ -56,12 +56,33 @@ export class AppComponent {
 		phone : 8595856547,
 		department : "Engineering"
 	}
-	];
+        ];
+
+        // Add few lecturers for initial listing
+        lecturersList = [
+        {
+                id : 1,
+                first_name : "Prof. Xavier",
+                last_name : "Smith",
+                email : "xavier@yopmail.com",
+                phone : 9876543210,
+                department : "Science"
+        },
+        {
+                id : 2,
+                first_name : "Dr. Jane",
+                last_name : "Doe",
+                email : "jane@yopmail.com",
+                phone : 9123456780,
+                department : "Arts"
+        }
+        ];
 
 	constructor() {
-		// Save students to localStorage
-		localStorage.setItem('students', JSON.stringify(this.studentsList));
-	}
+                // Save students and lecturers to localStorage
+                localStorage.setItem('students', JSON.stringify(this.studentsList));
+                localStorage.setItem('lecturers', JSON.stringify(this.lecturersList));
+        }
 }
 
 /**

--- a/src/app/components/lecturer/add/lecturer-add.component.css
+++ b/src/app/components/lecturer/add/lecturer-add.component.css
@@ -1,0 +1,5 @@
+/*Created By : Sangwin Gawande (https://sangw.in)*/
+form{
+	padding: 0px;
+}
+/*Created By : Sangwin Gawande (https://sangw.in)*/

--- a/src/app/components/lecturer/add/lecturer-add.component.html
+++ b/src/app/components/lecturer/add/lecturer-add.component.html
@@ -1,0 +1,30 @@
+<!-- Created By : Sangwin Gawande (https://sangw.in) -->
+
+<div class="w3-container" *ngIf="lecturerAddForm">
+        <form class="w3-container" [formGroup]="lecturerAddForm" (ngSubmit)="doRegister()">
+        <div class="w3-panel w3-round-small w3-teal">
+                <h3><span *ngIf="index == undefined">Lecturer Registration</span><span *ngIf="index != undefined">Lecturer Update</span> <a routerLink="/lecturers" class="w3-button w3-green custom-button"><i class="w3-medium fa fa-chevron-left"></i> Back</a></h3>
+        </div>
+
+		<label class="w3-text-blue"><i class="w3-medium custom-icon fa fa-user"></i><b>First Name</b></label>
+		<input class="w3-input w3-border" type="text" formControlName="first_name">
+                <div class="w3-panel w3-red"  *ngIf="lecturerAddForm.controls['first_name'].invalid && (lecturerAddForm.controls['first_name'].dirty || lecturerAddForm.controls['first_name'].touched)">Please enter 3 to 50 characters</div>
+
+		<label class="w3-text-blue"><i class="w3-medium custom-icon fa fa-user"></i><b>Last Name</b></label>
+		<input class="w3-input w3-border" type="text" formControlName="last_name">
+                <div class="w3-panel w3-red"  *ngIf="lecturerAddForm.controls['last_name'].invalid && (lecturerAddForm.controls['last_name'].dirty || lecturerAddForm.controls['last_name'].touched)">Please enter  3 to 50 characters </div>
+
+		<label class="w3-text-blue"><i class="w3-medium custom-icon fa fa-envelope-o"></i><b>Email Address</b></label>
+		<input class="w3-input w3-border" type="text" formControlName="email">
+                <div class="w3-panel w3-red"  *ngIf="lecturerAddForm.controls['email'].invalid && (lecturerAddForm.controls['email'].dirty || lecturerAddForm.controls['email'].touched)">Please enter valid email address</div>
+
+		<label class="w3-text-blue"><i class="w3-medium custom-icon fa fa-phone"></i><b>Phone</b></label>
+                <input class="w3-input w3-border" type="number" formControlName="phone">
+                <div class="w3-panel w3-red"  *ngIf="lecturerAddForm.controls['phone'].invalid && (lecturerAddForm.controls['phone'].dirty || lecturerAddForm.controls['phone'].touched)">Please enter valid phone number</div>
+		<br>
+                <button class="w3-btn w3-blue" type="submit" [disabled]="!lecturerAddForm.valid"><span *ngIf="index == undefined">Register</span><span *ngIf="index != undefined">Update</span> <i class="w3-medium fa fa-check"></i> </button>
+
+	</form>
+</div>
+
+<!-- Created By : Sangwin Gawande (https://sangw.in) -->

--- a/src/app/components/lecturer/add/lecturer-add.component.spec.ts
+++ b/src/app/components/lecturer/add/lecturer-add.component.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LecturerAddComponent } from './lecturer-add.component';
+
+describe('LecturerAddComponent', () => {
+  let component: LecturerAddComponent;
+  let fixture: ComponentFixture<LecturerAddComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LecturerAddComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LecturerAddComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */

--- a/src/app/components/lecturer/add/lecturer-add.component.ts
+++ b/src/app/components/lecturer/add/lecturer-add.component.ts
@@ -1,0 +1,92 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+import { Component, OnInit } from '@angular/core';
+import { Validators, FormBuilder, FormGroup } from '@angular/forms';
+import { RouterModule, Routes, Router, ActivatedRoute } from '@angular/router';
+
+// Services
+import { ValidationService } from '../../../services/config/config.service';
+import { LecturerService } from '../../../services/lecturer/lecturer.service';
+import { routerTransition } from '../../../services/config/config.service';
+
+import { ToastrService } from 'ngx-toastr';
+
+@Component({
+        selector: 'app-lecturer-add',
+        templateUrl: './lecturer-add.component.html',
+        styleUrls: ['./lecturer-add.component.css'],
+	animations: [routerTransition()],
+	host: { '[@routerTransition]': '' }
+})
+
+export class LecturerAddComponent implements OnInit {
+        // create lecturerAddForm of type FormGroup
+        lecturerAddForm: FormGroup;
+	index: any;
+
+        constructor(private formBuilder: FormBuilder, private router: Router, private route: ActivatedRoute, private lecturerService: LecturerService, private toastr: ToastrService) {
+
+		// Check for route params
+		this.route.params.subscribe(params => {
+			this.index = params['id'];
+			// check if ID exists in route & call update or add methods accordingly
+			if (this.index && this.index != null && this.index != undefined) {
+                                this.getLecturerDetails(this.index);
+			} else {
+				this.createForm(null);
+			}
+		});
+	}
+
+	ngOnInit() {
+	}
+
+        // Submit lecturer details form
+        doRegister() {
+                if (this.index && this.index != null && this.index != undefined) {
+                        this.lecturerAddForm.value.id = this.index
+                } else {
+                        this.index = null;
+                }
+                let lecturerRegister = this.lecturerService.doRegisterLecturer(this.lecturerAddForm.value, this.index);
+                if (lecturerRegister) {
+                        if (lecturerRegister.code == 200) {
+                                this.toastr.success(lecturerRegister.message, "Success");
+                                this.router.navigate(['/lecturers']);
+                        } else {
+                                this.toastr.error(lecturerRegister.message, "Failed");
+                        }
+                }
+        }
+
+        // If this is update form, get user details and update form
+        getLecturerDetails(index: number) {
+                let lecturerDetail = this.lecturerService.getLecturerDetails(index);
+                this.createForm(lecturerDetail);
+        }
+
+	// If this is update request then auto fill form
+	createForm(data: any) {
+		if (data == null) {
+                        this.lecturerAddForm = this.formBuilder.group({
+				first_name: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(50)]],
+				last_name: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(50)]],
+				phone: ['', [Validators.required, ValidationService.checkLimit(5000000000, 9999999999)]],
+				email: ['', [Validators.required, ValidationService.emailValidator]]
+			});
+		} else {
+                        this.lecturerAddForm = this.formBuilder.group({
+                                first_name: [data.lecturerData.first_name, [Validators.required, Validators.minLength(3), Validators.maxLength(50)]],
+                                last_name: [data.lecturerData.last_name, [Validators.required, Validators.minLength(3), Validators.maxLength(50)]],
+                                phone: [data.lecturerData.phone, [Validators.required, ValidationService.checkLimit(5000000000, 9999999999)]],
+                                email: [data.lecturerData.email, [Validators.required, ValidationService.emailValidator]]
+                        });
+                }
+        }
+
+}
+
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */

--- a/src/app/components/lecturer/details/lecturer-details.component.css
+++ b/src/app/components/lecturer/details/lecturer-details.component.css
@@ -1,0 +1,9 @@
+/*Created By : Sangwin Gawande (https://sangw.in)*/
+.margin-right{
+	margin-right: 10px;
+}
+.custom-card{
+	width: 50%;
+	margin:auto;
+}
+/*Created By : Sangwin Gawande (https://sangw.in)*/

--- a/src/app/components/lecturer/details/lecturer-details.component.html
+++ b/src/app/components/lecturer/details/lecturer-details.component.html
@@ -1,0 +1,31 @@
+<!-- Created By : Sangwin Gawande (https://sangw.in) -->
+
+<div class="w3-container" *ngIf="lecturerDetail">
+	<div class="w3-panel w3-round-small w3-teal">
+                <h3>Lecturer Details <button [routerLink]="['/lecturers/update', index]" class="w3-button w3-blue custom-button"> <i class="w3-medium fa fa-pencil"></i> Edit</button> <button routerLink="/lecturers" class="w3-button w3-green custom-button margin-right"> <i class="w3-medium fa fa-chevron-left"></i> Back</button></h3>
+	</div>
+	<div class=" w3-card custom-card"><br>
+                <h3 class="text-center">{{lecturerDetail.first_name}} {{lecturerDetail.last_name}}</h3>
+		<hr>
+		<table class="w3-table w3-bordered">
+			<tr>
+				<td><i class="w3-medium custom-icon fa fa-user"></i>First Name</td>
+                                <td>: <b>{{lecturerDetail.first_name}}</b></td>
+			</tr>
+			<tr>
+				<td><i class="w3-medium custom-icon fa fa-user"></i>Last name</td>
+                                <td>: <b>{{lecturerDetail.last_name}}</b></td>
+			</tr>
+			<tr>
+				<td><i class="w3-medium custom-icon fa fa-envelope-o"></i> Email Address</td>
+                                <td>: <b>{{lecturerDetail.email}}</b></td>
+			</tr>
+			<tr>
+				<td><i class="w3-medium custom-icon fa fa-phone"></i> Phone</td>
+                                <td>: <b>{{lecturerDetail.phone}}</b></td>
+			</tr>
+		</table>
+	</div>
+</div>
+
+<!-- Created By : Sangwin Gawande (https://sangw.in) -->

--- a/src/app/components/lecturer/details/lecturer-details.component.spec.ts
+++ b/src/app/components/lecturer/details/lecturer-details.component.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LecturerDetailsComponent } from './lecturer-details.component';
+
+describe('LecturerDetailsComponent', () => {
+  let component: LecturerDetailsComponent;
+  let fixture: ComponentFixture<LecturerDetailsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LecturerDetailsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LecturerDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */

--- a/src/app/components/lecturer/details/lecturer-details.component.ts
+++ b/src/app/components/lecturer/details/lecturer-details.component.ts
@@ -1,0 +1,50 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+ import { Component, OnInit } from '@angular/core';
+ import {Validators, FormBuilder, FormGroup} from '@angular/forms';
+ import { RouterModule, Routes ,Router,ActivatedRoute} from '@angular/router';
+ import { ToastrService } from 'ngx-toastr';
+
+ // Services
+import { LecturerService } from '../../../services/lecturer/lecturer.service';
+ import { routerTransition } from '../../../services/config/config.service';
+
+ @Component({
+        selector: 'app-lecturer-details',
+        templateUrl: './lecturer-details.component.html',
+        styleUrls: ['./lecturer-details.component.css'],
+ 	animations: [routerTransition()],
+ 	host: {'[@routerTransition]': ''}
+ })
+
+export class LecturerDetailsComponent implements OnInit {
+        index:any;
+        lecturerDetail:any;
+        constructor(private router: Router, private route: ActivatedRoute, private lecturerService:LecturerService,private toastr: ToastrService) {
+ 		// Get user detail index number sent in params
+ 		this.route.params.subscribe(params => {
+ 			this.index = params['id'];
+ 			if (this.index && this.index != null && this.index != undefined) {
+                                this.getLecturerDetails(this.index);
+ 			}
+ 		});
+ 	}
+
+ 	ngOnInit() {
+ 	}
+
+        // Get lecturer details
+        getLecturerDetails(index:number){
+                let getLecturerDetail = this.lecturerService.getLecturerDetails(index);
+                if(getLecturerDetail) {
+                        this.lecturerDetail = getLecturerDetail.lecturerData;
+                        this.toastr.success(getLecturerDetail.message,"Success");
+                }
+        }
+
+ }
+
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */

--- a/src/app/components/lecturer/list/lecturer-list.component.css
+++ b/src/app/components/lecturer/list/lecturer-list.component.css
@@ -1,0 +1,6 @@
+/*Created By : Sangwin Gawande (https://sangw.in)*/
+td {
+    vertical-align: middle;
+}
+
+/*Created By : Sangwin Gawande (https://sangw.in)*/

--- a/src/app/components/lecturer/list/lecturer-list.component.html
+++ b/src/app/components/lecturer/list/lecturer-list.component.html
@@ -1,0 +1,38 @@
+<!-- Created By : Sangwin Gawande (https://sangw.in) -->
+
+<div class="w3-container" *ngIf="lecturerListData">
+	<div class="w3-panel w3-round-small w3-teal">
+                <h3>Lecturer List <button routerLink="/lecturers/add" class="w3-button w3-green custom-button"><i class="w3-medium  fa fa-plus"></i> Add New Lecturer</button></h3>
+	</div>
+	<span><i class="w3-medium fa fa-search"></i> Search : <input class="" type="text" [(ngModel)]='filterData'></span>
+
+	<div class="w3-panel w3-green" *ngIf="(lecturerListData | filter:filterData).length == 0">
+		<h3>Oh no</h3>
+		<p>No lecturers found <span *ngIf="filterData"> with search "{{filterData}}"</span> </p>
+	</div>
+	<div class="w3-panel w3-light-grey w3-padding-16 w3-card-2" *ngIf="(lecturerListData | filter:filterData | filter:filterData).length != 0">
+		<table class="w3-table w3-striped w3-bordered">
+			<tr>
+				<th><i class="w3-medium custom-icon fa fa-refresh"></i> Sr. No.</th>
+				<!-- <th>ID</th> -->
+				<th><i class="w3-medium custom-icon fa fa-user"></i> First Name</th>
+				<th><i class="w3-medium custom-icon fa fa-user"></i> Last Name</th>
+				<th><i class="w3-medium custom-icon fa fa-envelope-o"></i> Email</th>
+				<th><i class="w3-medium custom-icon fa fa-phone"></i> Phone</th>
+				<th><i class="w3-medium custom-icon fa fa-pencil"></i> Update</th>
+				<th><i class="w3-medium custom-icon fa fa-trash"></i> Delete</th>
+			</tr>
+                        <tr *ngFor="let lecturer of lecturerListData | filter:filterData; index as i;" appHighlightStudent>
+				<td>{{i +1}}</td>
+				<td class="pointer" [routerLink]="['detail', i]">{{lecturer.first_name}} </td>
+				<td class="pointer" [routerLink]="['detail', i]">{{lecturer.last_name}}</td>
+				<td class="pointer" [routerLink]="['detail', i]">{{lecturer.email}}</td>
+				<td class="pointer" [routerLink]="['detail', i]">{{lecturer.phone | phone}}</td>
+				<td><button [routerLink]="['update', i]" class="w3-button w3-blue">Update</button></td>
+				<td><button (click)="deleteLecturer(i);" class="w3-button w3-red">Delete</button></td>
+			</tr>
+		</table>
+	</div>
+</div>
+
+<!-- Created By : Sangwin Gawande (https://sangw.in) -->

--- a/src/app/components/lecturer/list/lecturer-list.component.spec.ts
+++ b/src/app/components/lecturer/list/lecturer-list.component.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LecturerListComponent } from './lecturer-list.component';
+
+describe('LecturerListComponent', () => {
+  let component: LecturerListComponent;
+  let fixture: ComponentFixture<LecturerListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LecturerListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LecturerListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */

--- a/src/app/components/lecturer/list/lecturer-list.component.ts
+++ b/src/app/components/lecturer/list/lecturer-list.component.ts
@@ -1,0 +1,59 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
+
+// Services
+import { LecturerService } from '../../../services/lecturer/lecturer.service';
+import { routerTransition } from '../../../services/config/config.service';
+
+@Component({
+        selector: 'app-lecturer-list',
+        templateUrl: './lecturer-list.component.html',
+        styleUrls: ['./lecturer-list.component.css'],
+	animations: [routerTransition()],
+	host: { '[@routerTransition]': '' }
+})
+
+export class LecturerListComponent implements OnInit {
+        lecturerList: any;
+        lecturerListData: any;
+        filterData: string = '';
+        constructor(private lecturerService: LecturerService, private toastr: ToastrService) { }
+        // Call lecturer list function on page load
+        ngOnInit() {
+                this.getLecturerList();
+        }
+
+        // Get lecturer list from services
+        getLecturerList() {
+                let lecturerList = this.lecturerService.getAllLecturers();
+                this.success(lecturerList)
+        }
+
+        // Get lecturer list success
+        success(data: any) {
+                this.lecturerListData = data.data;
+                for (var i = 0; i < this.lecturerListData.length; i++) {
+                        this.lecturerListData[i].name = this.lecturerListData[i].first_name + ' ' + this.lecturerListData[i].last_name;
+                }
+        }
+
+        // Delete a lecturer with its index
+        deleteLecturer(index: number) {
+                // get confirm box for confirmation
+                let r = confirm("Are you sure?");
+                if (r == true) {
+                        let lecturerDelete = this.lecturerService.deleteLecturer(index);
+                        if (lecturerDelete) {
+                                this.toastr.success("Success", "Lecturer Deleted");
+                        }
+                        this.getLecturerList();
+                }
+        }
+}
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */

--- a/src/app/services/lecturer/lecturer.service.spec.ts
+++ b/src/app/services/lecturer/lecturer.service.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+
+import { TestBed, inject } from '@angular/core/testing';
+
+import { LecturerService } from './lecturer.service';
+
+describe('LecturerService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LecturerService]
+    });
+  });
+
+  it('should be created', inject([LecturerService], (service: LecturerService) => {
+    expect(service).toBeTruthy();
+  }));
+});
+
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */

--- a/src/app/services/lecturer/lecturer.service.ts
+++ b/src/app/services/lecturer/lecturer.service.ts
@@ -1,0 +1,117 @@
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */
+
+ import { Injectable } from '@angular/core';
+
+ @Injectable()
+export class LecturerService {
+
+   constructor() { }
+
+   // Get all students list via API or any data storage
+  getAllLecturers(){
+    let lecturerList:any;
+    if(localStorage.getItem('lecturers') && localStorage.getItem('lecturers') != '') {
+      lecturerList = {
+        code : 200,
+        message : "Lecturers List Fetched Successfully",
+        data : JSON.parse(localStorage.getItem('lecturers') || '')
+      }
+    }else{
+      lecturerList = {
+        code : 200,
+        message : "Lecturers List Fetched Successfully",
+        data : JSON.parse(localStorage.getItem('lecturers') || '')
+      }
+    }
+    return lecturerList;
+  }
+
+  doRegisterLecturer(data: any, index: number){
+    let lecturerList = JSON.parse(localStorage.getItem('lecturers') || '');
+    let returnData;
+    if(index != null) {
+      for (var i = 0; i < lecturerList.length; i++) {
+        if (index != i && lecturerList[i].email == data.email) {
+           returnData = {
+             code : 503,
+             message : "Email Address Already In Use",
+             data : null
+           }    
+           return returnData;
+         }
+       }
+
+       lecturerList[index] = data;
+       localStorage.setItem('lecturers',JSON.stringify(lecturerList));
+       returnData = {
+        code : 200,
+        message : "Lecturer Successfully Updated",
+        data : JSON.parse(localStorage.getItem('lecturers') || '')
+       }
+    }else{
+       data.id = this.generateRandomID();
+       for (var i = 0; i < lecturerList.length; i++) {
+         if (lecturerList[i].email == data.email) {
+           returnData = {
+             code : 503,
+             message : "Email Address Already In Use",
+             data : null
+           }    
+           return returnData;
+         }
+       }
+       lecturerList.unshift(data);
+
+       localStorage.setItem('lecturers',JSON.stringify(lecturerList));
+
+       returnData = {
+        code : 200,
+        message : "Lecturer Successfully Added",
+        data : JSON.parse(localStorage.getItem('lecturers') || '')
+       }
+    }
+    return returnData;
+  }
+
+  deleteLecturer(index:number){
+    let lecturerList = JSON.parse(localStorage.getItem('lecturers') || '');
+
+    lecturerList.splice(index, 1);
+
+    localStorage.setItem('lecturers',JSON.stringify(lecturerList));
+
+    let returnData = {
+      code : 200,
+      message : "Lecturer Successfully Deleted",
+      data : JSON.parse(localStorage.getItem('lecturers') || '')
+    }
+
+     return returnData;
+   }
+
+
+
+  getLecturerDetails(index:number){
+    let lecturerList = JSON.parse(localStorage.getItem('lecturers') || '');
+
+    let returnData = {
+      code : 200,
+      message : "Lecturer Details Fetched",
+      lecturerData : lecturerList[index]
+    }
+
+     return returnData;
+   }
+
+
+   generateRandomID() {
+     var x = Math.floor((Math.random() * Math.random() * 9999));
+     return x;
+   }
+
+ }
+/**
+ * Created By : Sangwin Gawande (https://sangw.in)
+ */


### PR DESCRIPTION
## Summary
- copy student management logic to manage lecturers
- wire up lecturer routes and sidebar menu
- store sample lecturers in local storage on app start

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f06276fc83329f6155d82e0dd234