### PR TITLE
Fix tests to use headless Chrome

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,9 +36,9 @@ module.exports = function (config) {
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false,
+    autoWatch: false,
+    browsers: ['ChromeHeadless'],
+    singleRun: true,
     restartOnFileChange: true
   });
 };


### PR DESCRIPTION
## Summary
- run karma in headless mode so Chrome is not required on the host

## Testing
- `CI=true npm test` *(fails: Chrome cannot start because chromium snap cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68481474e8e08332a2b09060b9147200